### PR TITLE
Fixed non-handling of HTML annotations (book info)

### DIFF
--- a/src/org/geometerplus/android/fbreader/BookInfoActivity.java
+++ b/src/org/geometerplus/android/fbreader/BookInfoActivity.java
@@ -27,6 +27,7 @@ import android.app.Activity;
 import android.content.Intent;
 import android.graphics.Bitmap;
 import android.os.Bundle;
+import android.text.Html;
 import android.util.DisplayMetrics;
 import android.view.View;
 import android.view.Window;
@@ -252,7 +253,7 @@ public class BookInfoActivity extends Activity {
 			bodyView.setVisibility(View.GONE);
 		} else {
 			titleView.setText(myResource.getResource("annotation").getValue());
-			bodyView.setText(annotation);
+			bodyView.setText(Html.fromHtml(annotation));
 		}
 	}
 


### PR DESCRIPTION
Books info may have HTML content for description in the annotation
section. The issue may occur for example when using an external OPDS
catalog created with Calibre and exported with calibre2opds.

This patch simply turns on HTML support in the annotation field.

https://rapidshare.com/files/459720133/badhtmlhandling.png
http://rapidshare.com/files/459719756/goodhtmlhandling.png
