### PR TITLE
Decimal mark appropriate to language

### DIFF
--- a/assets/resources/application/ca.xml
+++ b/assets/resources/application/ca.xml
@@ -399,6 +399,7 @@
 			<node name="lineSpacing" value="Interliniat">
 				<node name="unchanged" value="&lt;sense canvis&gt;"/>
 			</node>
+			<node name="decimalMark" value=","/>
 			<node name="alignment" value="Aliniació">
 				<node name="left" value="Esquerra"/>
 				<node name="right" value="Dreta"/>

--- a/assets/resources/application/de.xml
+++ b/assets/resources/application/de.xml
@@ -389,6 +389,7 @@
 			<node name="lineSpacing" value="Zeilenabstand">
 				<node name="unchanged" value="&lt;unverändert&gt;"/>
 			</node>
+			<node name="decimalMark" value=","/>
 			<node name="alignment" value="Ausrichtung">
 				<node name="left" value="Links"/>
 				<node name="right" value="Rechts"/>

--- a/assets/resources/application/en.xml
+++ b/assets/resources/application/en.xml
@@ -395,6 +395,7 @@
 			<node name="lineSpacing" value="Line Spacing">
 				<node name="unchanged" value="&lt;unchanged&gt;"/>
 			</node>
+			<node name="decimalMark" value="."/>
 			<node name="alignment" value="Alignment">
 				<node name="left" value="Left"/>
 				<node name="right" value="Right"/>

--- a/assets/resources/application/es.xml
+++ b/assets/resources/application/es.xml
@@ -400,6 +400,8 @@
 			<node name="lineSpacing" value="Interlineado">
 				<node name="unchanged" value="&lt;sin cambios&gt;"/>
 			</node>
+			<!-- decimalMark is ',' in Spain, Argentina etc. and '.' in Peru, Mexico etc. -->
+			<node name="decimalMark" value=","/>
 			<node name="alignment" value="Alineación">
 				<node name="left" value="Izquierda"/>
 				<node name="right" value="Derecha"/>

--- a/assets/resources/application/fr.xml
+++ b/assets/resources/application/fr.xml
@@ -388,6 +388,7 @@
 			<node name="lineSpacing" value="Espacement de lignes">
 				<node name="unchanged" value="&lt;inchangé&gt;"/>
 			</node>
+			<node name="decimalMark" value=","/>
 			<node name="alignment" value="Alignement">
 				<node name="left" value="Gauche"/>
 				<node name="right" value="Droite"/>

--- a/assets/resources/application/hu.xml
+++ b/assets/resources/application/hu.xml
@@ -385,6 +385,7 @@
 			<node name="lineSpacing" value="Sorköz">
 				<node name="unchanged" value="&lt;változatlan&gt;"/>
 			</node>
+			<node name="decimalMark" value=","/>
 			<node name="alignment" value="Igazítás">
 				<node name="left" value="Balra"/>
 				<node name="right" value="Jobbra"/>

--- a/assets/resources/application/it.xml
+++ b/assets/resources/application/it.xml
@@ -386,6 +386,7 @@
 			<node name="lineSpacing" value="Interlinea">
 				<node name="unchanged" value="&lt;non cambiare&gt;"/>
 			</node>
+			<node name="decimalMark" value=","/>
 			<node name="alignment" value="Allineamento">
 				<node name="left" value="Sinistra"/>
 				<node name="right" value="Destra"/>

--- a/assets/resources/application/nb.xml
+++ b/assets/resources/application/nb.xml
@@ -395,6 +395,7 @@
 			<node name="lineSpacing" value="Linjeavstand">
 				<node name="unchanged" value="&lt;uforandret&gt;"/>
 			</node>
+			<node name="decimalMark" value=","/>
 			<node name="alignment" value="Justering">
 				<node name="left" value="Venstre"/>
 				<node name="right" value="Høyre"/>

--- a/assets/resources/application/nl.xml
+++ b/assets/resources/application/nl.xml
@@ -395,6 +395,7 @@
 			<node name="lineSpacing" value="Regelafstand">
 				<node name="unchanged" value="&lt;ongewijzigd&gt;"/>
 			</node>
+			<node name="decimalMark" value=","/>
 			<node name="alignment" value="Uitlijning">
 				<node name="left" value="Links"/>
 				<node name="right" value="Rechts"/>

--- a/assets/resources/application/pl.xml
+++ b/assets/resources/application/pl.xml
@@ -385,6 +385,8 @@
 			<node name="lineSpacing" value="Interlinia">
 				<node name="unchanged" value="&lt;bez zmian&gt;"/>
 			</node>
+			<node name="decimalMark" value=","/>
+			<node name="spaceBefore" value="Odstęp przed"/>
 			<node name="alignment" value="Wyrównanie">
 				<node name="left" value="Do lewej"/>
 				<node name="right" value="Do prawej"/>

--- a/assets/resources/application/pt.xml
+++ b/assets/resources/application/pt.xml
@@ -397,6 +397,7 @@
 			<node name="lineSpacing" value="Espaçamento entre linhas">
 				<node name="unchanged" value="&lt;sem alteração&gt;"/>
 			</node>
+			<node name="decimalMark" value=","/>
 			<node name="alignment" value="Alinhamento">
 				<node name="left" value="Esquerda"/>
 				<node name="right" value="Direita"/>

--- a/assets/resources/application/sr.xml
+++ b/assets/resources/application/sr.xml
@@ -395,6 +395,7 @@
 			<node name="lineSpacing" value="Размак између редова">
 				<node name="unchanged" value="&lt;непромењено&gt;"/>
 			</node>
+			<node name="decimalMark" value=","/>
 			<node name="alignment" value="Поравнање">
 				<node name="left" value="Лево"/>
 				<node name="right" value="Десно"/>

--- a/assets/resources/application/zh.xml
+++ b/assets/resources/application/zh.xml
@@ -385,6 +385,7 @@
 			<node name="lineSpacing" value="行间距">
 				<node name="unchanged" value="&lt;不变&gt;"/>
 			</node>
+			<node name="decimalMark" value="."/>
 			<node name="alignment" value="对齐">
 				<node name="left" value="左"/>
 				<node name="right" value="右"/>

--- a/src/org/geometerplus/android/fbreader/preferences/PreferenceActivity.java
+++ b/src/org/geometerplus/android/fbreader/preferences/PreferenceActivity.java
@@ -168,9 +168,10 @@ public class PreferenceActivity extends ZLPreferenceActivity {
 		));
 		final ZLIntegerRangeOption spaceOption = baseStyle.LineSpaceOption;
 		final String[] spacings = new String[spaceOption.MaxValue - spaceOption.MinValue + 1];
+		final String decimalMark = textScreen.Resource.getResource("decimalMark").getValue();
 		for (int i = 0; i < spacings.length; ++i) {
 			final int val = spaceOption.MinValue + i;
-			spacings[i] = (char)(val / 10 + '0') + "." + (char)(val % 10 + '0');
+			spacings[i] = (char)(val / 10 + '0') + decimalMark + (char)(val % 10 + '0');
 		}
 		textScreen.addPreference(new ZLChoicePreference(
 			this, textScreen.Resource, "lineSpacing",
@@ -284,12 +285,13 @@ public class PreferenceActivity extends ZLPreferenceActivity {
 				final ZLIntegerOption spacePercentOption = fullDecoration.LineSpacePercentOption;
 				final int[] spacingValues = new int[17];
 				final String[] spacingKeys = new String[17];
+				final String decimalMarker = textScreen.Resource.getResource("decimalMark").getValue();
 				spacingValues[0] = -1;
 				spacingKeys[0] = "unchanged";
 				for (int j = 1; j < spacingValues.length; ++j) {
 					final int val = 4 + j;
 					spacingValues[j] = 10 * val;
-					spacingKeys[j] = (char)(val / 10 + '0') + "." + (char)(val % 10 + '0');
+					spacingKeys[j] = (char)(val / 10 + '0') + decimalMarker + (char)(val % 10 + '0');
 				}
 				formatScreen.addPreference(new ZLIntegerChoicePreference(
 					this, textScreen.Resource, "lineSpacing",


### PR DESCRIPTION
Most continental European and South American countries use a comma for
the decimal mark.

The USA, Ireland, China, Japan etc. use a period for the decimal mark.

Regarding the Spanish language:
- Spain, Argentina, Chile etc. use a comma.
- Mexico, Guatemala, Peru etc. use a period.

We will deal with thes more specific subtleties of Spanish, as well as
other languages, in the future.
