### PR TITLE
potential improvement for responsiveness in FBReaderJ

### DIFF
--- a/src/org/geometerplus/android/fbreader/image/ImageViewActivity.java
+++ b/src/org/geometerplus/android/fbreader/image/ImageViewActivity.java
@@ -23,6 +23,7 @@ import android.app.Activity;
 import android.content.Intent;
 import android.graphics.*;
 import android.net.Uri;
+import android.os.AsyncTask;
 import android.os.Bundle;
 import android.util.FloatMath;
 import android.view.*;
@@ -68,19 +69,31 @@ public class ImageViewActivity extends Activity {
 
 		final Uri uri = intent.getData();
 		if (ZLFileImage.SCHEME.equals(uri.getScheme())) {
-			final ZLFileImage image = ZLFileImage.byUrlPath(uri.getPath());
-			if (image == null) {
-				// TODO: error message (?)
-				finish();
-			}
-			try {
-				final ZLImageData imageData = ZLImageManager.Instance().getImageData(image);
-				myBitmap = ((ZLAndroidImageData)imageData).getFullSizeBitmap();
-			} catch (Exception e) {
-				// TODO: error message (?)
-				e.printStackTrace();
-				finish();
-			}
+			new AsyncTask<Uri, Void, Boolean>() {
+				protected Boolean doInBackground(Uri... args) {
+					Uri uri = args[0];
+					final ZLFileImage image = ZLFileImage.byUrlPath(uri.getPath());
+					if (image == null) {
+						return false;
+					}
+					
+					try {
+						final ZLImageData imageData = ZLImageManager.Instance().getImageData(image);
+						myBitmap = ((ZLAndroidImageData)imageData).getFullSizeBitmap();
+					} catch (Exception e) {
+						e.printStackTrace();
+						return false;
+					}
+					return true;
+				}
+
+				protected void onPostExecute(Boolean result) {
+					if(!result) {
+						// TODO: error message (?)
+						finish();
+					}
+				}
+			}.execute(uri);
 		} else {
 			// TODO: error message (?)
 			finish();

--- a/src/org/geometerplus/android/fbreader/library/LibraryActivity.java
+++ b/src/org/geometerplus/android/fbreader/library/LibraryActivity.java
@@ -22,6 +22,7 @@ package org.geometerplus.android.fbreader.library;
 import android.app.AlertDialog;
 import android.app.SearchManager;
 import android.content.*;
+import android.os.AsyncTask;
 import android.os.Bundle;
 import android.view.*;
 import android.widget.AdapterView;
@@ -220,24 +221,57 @@ public class LibraryActivity extends TreeActivity<LibraryTree> implements MenuIt
 				return true;
 			case ADD_TO_FAVORITES_ITEM_ID:
 				book.addLabel(Book.FAVORITE_LABEL);
-				myRootTree.Collection.saveBook(book);
+				new AsyncTask<Book, Void, Void>() {
+					protected Void doInBackground(Book... args) {
+						Book book = args[0];
+						myRootTree.Collection.saveBook(book);
+						return null;
+					}
+				}.execute(book);
 				return true;
 			case REMOVE_FROM_FAVORITES_ITEM_ID:
 				book.removeLabel(Book.FAVORITE_LABEL);
-				myRootTree.Collection.saveBook(book);
-				if (getCurrentTree().onBookEvent(BookEvent.Updated, book)) {
-					getListAdapter().replaceAll(getCurrentTree().subtrees(), true);
-				}
+				new AsyncTask<Book, Void, Book>() {
+					protected Book doInBackground(Book... args) {
+						Book book = args[0];
+						myRootTree.Collection.saveBook(book);
+						return book;
+					}
+
+					protected void onPostExecute(Book book) {
+						if (getCurrentTree().onBookEvent(BookEvent.Updated, book)) {
+							getListAdapter().replaceAll(getCurrentTree().subtrees(), true);
+						}
+					}
+				}.execute(book);
 				return true;
 			case MARK_AS_READ_ITEM_ID:
 				book.addLabel(Book.READ_LABEL);
-				myRootTree.Collection.saveBook(book);
-				getListView().invalidateViews();
+				new AsyncTask<Book, Void, Void>() {
+					protected Void doInBackground(Book... args) {
+						Book book = args[0];
+						myRootTree.Collection.saveBook(book);
+						return null;
+					}
+
+					protected void onPostExecute(Void v) {
+						getListView().invalidateViews();
+					}
+				}.execute(book);
 				return true;
 			case MARK_AS_UNREAD_ITEM_ID:
 				book.removeLabel(Book.READ_LABEL);
-				myRootTree.Collection.saveBook(book);
-				getListView().invalidateViews();
+				new AsyncTask<Book, Void, Void>() {
+					protected Void doInBackground(Book... args) {
+						Book book = args[0];
+						myRootTree.Collection.saveBook(book);
+						return null;
+					}
+
+					protected void onPostExecute(Void v) {
+						getListView().invalidateViews();
+					}
+				}.execute(book);
 				return true;
 			case DELETE_BOOK_ITEM_ID:
 				tryToDeleteBook(book);
@@ -367,5 +401,5 @@ public class LibraryActivity extends TreeActivity<LibraryTree> implements MenuIt
 
 	public void onBuildEvent(IBookCollection.Status status) {
 		setProgressBarIndeterminateVisibility(!status.IsCompleted);
-	}
+	}	
 }

--- a/src/org/geometerplus/android/fbreader/network/NetworkBookInfoActivity.java
+++ b/src/org/geometerplus/android/fbreader/network/NetworkBookInfoActivity.java
@@ -26,6 +26,7 @@ import android.content.Intent;
 import android.content.res.ColorStateList;
 import android.graphics.Bitmap;
 import android.net.Uri;
+import android.os.AsyncTask;
 import android.os.Bundle;
 import android.text.method.LinkMovementMethod;
 import android.util.DisplayMetrics;
@@ -308,7 +309,6 @@ public class NetworkBookInfoActivity extends Activity implements NetworkLibrary.
 
 		final int maxHeight = metrics.heightPixels * 2 / 3;
 		final int maxWidth = maxHeight * 2 / 3;
-		Bitmap coverBitmap = null;
 		final ZLImage cover = NetworkTree.createCover(myBook);
 		if (cover != null) {
 			ZLAndroidImageData data = null;
@@ -334,14 +334,23 @@ public class NetworkBookInfoActivity extends Activity implements NetworkLibrary.
 				data = mgr.getImageData(cover);
 			}
 			if (data != null) {
-				coverBitmap = data.getBitmap(maxWidth, maxHeight);
+				new AsyncTask<ZLAndroidImageData, Void, Bitmap>() {
+					protected Bitmap doInBackground(ZLAndroidImageData... args) {
+						ZLAndroidImageData data = args[0];
+						Bitmap coverBitmap = data.getBitmap(maxWidth, maxHeight);
+						return coverBitmap;
+					}
+					
+					protected void onPostExecute(Bitmap coverBitmap) {
+						if (coverBitmap != null) {
+							coverView.setImageBitmap(coverBitmap);
+							coverView.setVisibility(View.VISIBLE);
+						} else {
+							coverView.setVisibility(View.GONE);
+						}
+					}
+				}.execute(data);
 			}
-		}
-		if (coverBitmap != null) {
-			coverView.setImageBitmap(coverBitmap);
-			coverView.setVisibility(View.VISIBLE);
-		} else {
-			coverView.setVisibility(View.GONE);
 		}
 	}
 


### PR DESCRIPTION
Dear developers of FBReaderJ,

I'm a Ph.D. student and I'm doing research related to Android apps'
responsiveness. I found there are some cases in FBReaderJ that the
database is queried, or bitmap is generated in UI thread. Does this
affect the responsiveness of the app? An optimization could be
extracting these operations into AsyncTask.

For example, in ImageViewActivity.java, line 78 generates a bitmap
(invokes "getImageData"), which is a long computation. Is it better to
put them into a AsyncTask, so the onCreate method won't be blocked? I
attach a sample patch here. Note that there are data races on
"myBitmap" after this change, but I think the races won't lead to bugs
because you've checked if "myBitmap" is null before use it in "onDraw"
method.

Similarly, I also transformed ZLAndroidPaintContext.java,
BookInfoActivity.java, NetworkBookInfoActivity.java, since they are
also trying to get Bitmap in UI thread.

Also, in BookInfoActivity.java and LibraryActivity.java, there are
several access to IO/database in UI Thread. E.g.,
BookInfoActivity.java line 116 invokes "myBook.reloadInfoFromFile()".
This also lead to a potential responsiveness issue. Thus, I tried to
move it into AsyncTask. Similarly, LibraryActivity.java invokes 
"myRootTree.Collection.saveBook" several times, which executes a
database transaction.

There should be some other places that can be improved. I can't report
all of them since I checked the code manually and it takes time. However, 
what do you think about these improvements? My thought is we can improve the
responsiveness if we try to avoid the access to IO/Database, computing bitmap in 
UI thread.

Thanks,
Yu
