### PR TITLE
Fix build instructions

### DIFF
--- a/HowToBuild
+++ b/HowToBuild
@@ -20,8 +20,16 @@ E.g., on my computer 'local.properties' consists of 2 lines:
   sdk.dir=/Users/geometer/android-sdk-mac_86
   ndk.dir=/Users/geometer/android-ndk-r4b
 
-2. If you use Linux or MacOS, just run 'ant package' and go to step 3. For debugging 
-purposes, you might want to run 'ant dbg' for building the package in debug mode, signing 
+2. Tune the setup before compiling:
+  2a. by copying your 'local.properties' to those third-party code directories:
+      cp local.properties third-party/android-filechooser/code/
+      cp local.properties third-party/drag-sort-listview/library/
+      cp local.properties third-party/AmbilWarna/
+  2b. by copying the Android support v4 lib:
+      cp libs/android-support-v4.jar third-party/drag-sort-listview/library/libs/
+
+2. If you use Linux or MacOS, just run 'ant dist' and go to step 3. For debugging
+purposes, you might want to run 'ant debug' for building the package in debug mode, signing
 with your debug key (in this case, you can skip step 3).
 
 If you are Windows user

--- a/third-party/drag-sort-listview/library/project.properties
+++ b/third-party/drag-sort-listview/library/project.properties
@@ -12,4 +12,4 @@
 
 android.library=true
 # Project target.
-target=android-5
+target=android-7


### PR DESCRIPTION
As stated in #253, the build instructions need to be updated. 

This patch only fix the docs but in the future, I think 2a and 2b should be handled automatically by adding a specifig Ant target.