### PR TITLE
Fixes #140, Redundant percentage sign in settings

### DIFF
--- a/src/org/geometerplus/android/fbreader/preferences/ZLStringListPreference.java
+++ b/src/org/geometerplus/android/fbreader/preferences/ZLStringListPreference.java
@@ -45,7 +45,11 @@ abstract class ZLStringListPreference extends ListPreference {
 		String[] texts = new String[values.length];
 		for (int i = 0; i < values.length; ++i) {
 			final ZLResource resource = myValuesResource.getResource(values[i]);
-			texts[i] = resource.hasValue() ? resource.getValue() : values[i];
+			// It appears that setEntries() DOES NOT perform any extra formatting on the char
+			// sequences, so to get just a single %, we'd have to perform the substitution manually.
+			// http://developer.android.com/reference/android/preference/ListPreference.html#setEntries(java.lang.CharSequence[])
+			// TODO: We should probably do an assert() and tell people to check their xml here.
+			texts[i] = resource.hasValue() ? resource.getValue().replace("%%","%") : values[i];
 		}
 		setLists(values, texts);
 	}
@@ -70,7 +74,12 @@ abstract class ZLStringListPreference extends ListPreference {
 			}
 		}
 		setValueIndex(index);
-		setSummary(getEntry());
+		// We have previously called setEntries() on the assumption that it does not perform any
+		// extra formatting on the char sequences.
+		// However, setSummary() DOES perform extra formatting on the char sequences, so we'd need
+		// to correct this.
+		// http://developer.android.com/reference/android/preference/ListPreference.html#setSummary(java.lang.CharSequence)
+		setSummary(getEntry().toString().replace("%", "%%"));
 		return found;
 	}
 
@@ -78,7 +87,7 @@ abstract class ZLStringListPreference extends ListPreference {
 	protected void onDialogClosed(boolean result) {
 		super.onDialogClosed(result);
 		if (result) {
-			setSummary(getEntry());
+			setSummary(getEntry().toString().replace("%", "%%"));
 		}
 	}
 }


### PR DESCRIPTION
This should fix the duplicate percent signs issue seen in the non-english languages (#140). I have tested this and have assured that this would not break anything else, assuming the language xmls are not malformed (note the TODO).

This "bug" is the result of an inconsistency in Google's decision to format the Char Sequences in setSummary() but not formatting the Char Sequences in setEntries().

http://developer.android.com/reference/android/preference/ListPreference.html#setEntries(java.lang.CharSequence[])

http://developer.android.com/reference/android/preference/ListPreference.html#setSummary(java.lang.CharSequence)

This explains the single percent signs shown in the summaries (eg: the summary in settings>appearance>"Prevent screen from sleeping"), since they have been properly escaped, and the double percent signs in the entries, since no formatting actually takes place there.