### PR TITLE
Improved handling of the backkey longpress, added more actions to backkey/backkey longpress screens.

### DIFF
--- a/assets/resources/application/en.xml
+++ b/assets/resources/application/en.xml
@@ -795,11 +795,18 @@
 			</node>
 			<node name="backKeyAction" value="Back key action">
 				<node name="exit" value="Close FBReader"/>
+				<node name="goToPreviousBook" value="Go directly to your previously opened book"/>
+				<node name="goToLibrary" value="Go directly to your library"/>
+				<node name="goToNetworkLibrary" value="Go directly to your network library"/>
 				<node name="goBack" value="Navigate back"/>
 				<node name="cancelMenu" value="Show cancel menu"/>
+				<node name="none" value="No action"/>
 			</node>
 			<node name="backKeyLongPressAction" value="Back key long press action">
 				<node name="exit" value="Close FBReader"/>
+				<node name="goToPreviousBook" value="Go directly to your previously opened book"/>
+				<node name="goToLibrary" value="Go directly to your library"/>
+				<node name="goToNetworkLibrary" value="Go directly to your network library"/>
 				<node name="goBack" value="Navigate back"/>
 				<node name="cancelMenu" value="Show cancel menu"/>
 				<node name="none" value="No action"/>

--- a/src/org/geometerplus/android/fbreader/FBReader.java
+++ b/src/org/geometerplus/android/fbreader/FBReader.java
@@ -286,6 +286,9 @@ public final class FBReader extends Activity implements ZLApplicationWindow {
 		myFBReaderApp.addAction(ActionCode.OPEN_VIDEO, new OpenVideoAction(this, myFBReaderApp));
 
 		myFBReaderApp.addAction(ActionCode.SHOW_CANCEL_MENU, new ShowCancelMenuAction(this, myFBReaderApp));
+		myFBReaderApp.addAction(ActionCode.GO_TO_LIBRARY, new ShowLibraryAction(this, myFBReaderApp));
+		myFBReaderApp.addAction(ActionCode.GO_TO_NETWORK_LIBRARY, new ShowNetworkLibraryAction(this, myFBReaderApp));
+		myFBReaderApp.addAction(ActionCode.GO_TO_PREVIOUS_BOOK, new GoToPreviousBookAction(this, myFBReaderApp));
 		myFBReaderApp.addAction(ActionCode.OPEN_START_SCREEN, new StartScreenAction(this, myFBReaderApp));
 
 		myFBReaderApp.addAction(ActionCode.SET_SCREEN_ORIENTATION_SYSTEM, new SetScreenOrientationAction(this, myFBReaderApp, ZLibrary.SCREEN_ORIENTATION_SYSTEM));

--- a/src/org/geometerplus/android/fbreader/preferences/PreferenceActivity.java
+++ b/src/org/geometerplus/android/fbreader/preferences/PreferenceActivity.java
@@ -716,14 +716,24 @@ public class PreferenceActivity extends ZLPreferenceActivity {
 		cancelMenuScreen.addOption(cancelMenuHelper.ShowNetworkLibraryItemOption, "networkLibrary");
 		cancelMenuScreen.addOption(cancelMenuHelper.ShowPreviousBookItemOption, "previousBook");
 		cancelMenuScreen.addOption(cancelMenuHelper.ShowPositionItemsOption, "positions");
-		final String[] backKeyActions =
-			{ ActionCode.EXIT, ActionCode.SHOW_CANCEL_MENU };
+		final String[] backKeyActions = {
+			ActionCode.SHOW_CANCEL_MENU,
+			ActionCode.GO_TO_LIBRARY,
+			ActionCode.GO_TO_NETWORK_LIBRARY,
+			ActionCode.GO_TO_PREVIOUS_BOOK,
+			ActionCode.EXIT,
+			FBReaderApp.NoAction };
 		cancelMenuScreen.addPreference(new ZLStringChoicePreference(
 			this, cancelMenuScreen.Resource.getResource("backKeyAction"),
 			keyBindings.getOption(KeyEvent.KEYCODE_BACK, false), backKeyActions
 		));
-		final String[] backKeyLongPressActions =
-			{ ActionCode.EXIT, ActionCode.SHOW_CANCEL_MENU, FBReaderApp.NoAction };
+		final String[] backKeyLongPressActions = {
+			ActionCode.SHOW_CANCEL_MENU,
+			ActionCode.GO_TO_LIBRARY,
+			ActionCode.GO_TO_NETWORK_LIBRARY,
+			ActionCode.GO_TO_PREVIOUS_BOOK,
+			ActionCode.EXIT,
+			FBReaderApp.NoAction };
 		cancelMenuScreen.addPreference(new ZLStringChoicePreference(
 			this, cancelMenuScreen.Resource.getResource("backKeyLongPressAction"),
 			keyBindings.getOption(KeyEvent.KEYCODE_BACK, true), backKeyLongPressActions

--- a/src/org/geometerplus/fbreader/fbreader/ActionCode.java
+++ b/src/org/geometerplus/fbreader/fbreader/ActionCode.java
@@ -56,6 +56,9 @@ public interface ActionCode {
 	String GO_BACK = "goBack";
 	String EXIT = "exit";
 	String SHOW_CANCEL_MENU = "cancelMenu";
+	String GO_TO_LIBRARY = "goToLibrary";
+	String GO_TO_NETWORK_LIBRARY = "goToNetworkLibrary";
+	String GO_TO_PREVIOUS_BOOK = "goToPreviousBook";
 
 	String SET_SCREEN_ORIENTATION_SYSTEM = "screenOrientationSystem";
 	String SET_SCREEN_ORIENTATION_SENSOR = "screenOrientationSensor";

--- a/src/org/geometerplus/fbreader/fbreader/GoToPreviousBookAction.java
+++ b/src/org/geometerplus/fbreader/fbreader/GoToPreviousBookAction.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2007-2014 Geometer Plus <contact@geometerplus.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+package org.geometerplus.android.fbreader;
+
+import org.geometerplus.fbreader.book.Book;
+import org.geometerplus.fbreader.fbreader.FBReaderApp;
+
+import group.pals.android.lib.ui.filechooser.utils.ui.Dlg;
+
+class GoToPreviousBookAction extends FBAndroidAction {
+	GoToPreviousBookAction(FBReader baseActivity, FBReaderApp fbreader) {
+		super(baseActivity, fbreader);
+	}
+
+	@Override
+	protected void run(Object ... params) {
+		Book recentBook = Reader.Collection.getRecentBook(1);
+		// TODO: use resource file
+		Dlg.toast(BaseActivity, recentBook == null ?
+				"No previous book" : "Returned to " + recentBook.getTitle(), 1);
+		Reader.openBook(recentBook, null, null, null);
+	}
+}

--- a/src/org/geometerplus/zlibrary/ui/android/view/ZLAndroidWidget.java
+++ b/src/org/geometerplus/zlibrary/ui/android/view/ZLAndroidWidget.java
@@ -447,7 +447,13 @@ public class ZLAndroidWidget extends View implements ZLViewWidget, View.OnLongCl
 			bindings.hasBinding(keyCode, false)) {
 			if (myKeyUnderTracking != -1) {
 				if (myKeyUnderTracking == keyCode) {
-					return true;
+					final boolean longPress = System.currentTimeMillis() >
+							myTrackingStartTime + ViewConfiguration.getLongPressTimeout()/3;
+					if(longPress) {
+						application.runActionByKey(keyCode, longPress);
+						myKeyUnderTracking = -1;
+					}
+					return longPress;
 				} else {
 					myKeyUnderTracking = -1;
 				}
@@ -468,9 +474,7 @@ public class ZLAndroidWidget extends View implements ZLViewWidget, View.OnLongCl
 	public boolean onKeyUp(int keyCode, KeyEvent event) {
 		if (myKeyUnderTracking != -1) {
 			if (myKeyUnderTracking == keyCode) {
-				final boolean longPress = System.currentTimeMillis() >
-					myTrackingStartTime + ViewConfiguration.getLongPressTimeout();
-				ZLApplication.Instance().runActionByKey(keyCode, longPress);
+				ZLApplication.Instance().runActionByKey(keyCode, false);
 			}
 			myKeyUnderTracking = -1;
 			return true;


### PR DESCRIPTION
Fulfills #269. 

Long keypresses have been changed to not require the user to lift their fingers to activate. Instead, the callback would be trigger the moment the user has held on long enough. 

Adds new actions to the backkey/backkey longpress screens that lets the user switch directly to their book/to their library/to their network library.