### PR TITLE
Add Aard 2 dictionary support

### DIFF
--- a/assets/dictionaries/main.xml
+++ b/assets/dictionaries/main.xml
@@ -80,6 +80,12 @@
 		pattern="%s"
 	/>
 	<dictionary
+		id="Aard 2"
+		action="aard2.lookup"
+		dataKey="query"
+		pattern="%s"
+	/>
+	<dictionary
 		id="LEO Dictionary"
 		package="org.leo.android.dict"
 		class=".LeoDict"


### PR DESCRIPTION
Aard 2 (http://aarddict.org) is a successor to Aard Dictionary. It comes with redesigned user interface, more features (bookmarks, history, night mode, vector math rendering) and a better dictionary storage format.