### PR TITLE
Add ShowProgressAsPercentage option

### DIFF
--- a/assets/resources/application/ar.xml
+++ b/assets/resources/application/ar.xml
@@ -707,10 +707,6 @@
 				<node name="summaryOn" value="عرض علامات الفهرس على شريط التقدم"/>
 				<node name="summaryOff" value="لا تعرض علامات الفهرس على شريط التقدم"/>
 			</node>
-			<node name="showProgress" value="عرض رقم الصفحة">
-				<node name="summaryOn" value="عرض رقم الصفحة في الحاشية"/>
-				<node name="summaryOff" value="لا تعرض رقم الصفحة في الحاشية"/>
-			</node>
 			<node name="showBattery" value="عرض مستوى شحن البطارية">
 				<node name="summaryOn" value="عرض مستوى شحن البطارية في الحاشية"/>
 				<node name="summaryOff" value="لا تعرض مستوى شحن البطارية في الحاشية"/>

--- a/assets/resources/application/be.xml
+++ b/assets/resources/application/be.xml
@@ -709,10 +709,6 @@
 				<node name="summaryOn" value="Паказваць пазнакі зьместу ў прыпятку"/>
 				<node name="summaryOff" value="Не паказваць пазнакі зьместу ў прыпятку"/>
 			</node>
-			<node name="showProgress" value="Паказваць нумар старонкі">
-				<node name="summaryOn" value="Паказваць нумар старонкі ў прыпятку"/>
-				<node name="summaryOff" value="Не паказваць нумар старонкі ў прыпятку"/>
-			</node>
 			<node name="showBattery" value="Паказваць узровень батарэі">
 				<node name="summaryOn" value="Паказваць узровень батарэі ў прыпятку"/>
 				<node name="summaryOff" value="Не паказваць узровень батарэі ў прыпятку"/>

--- a/assets/resources/application/bg.xml
+++ b/assets/resources/application/bg.xml
@@ -715,10 +715,6 @@
 				<node name="summaryOn" value="Покажи съдържание по раздели в долния колонтитул"/>
 				<node name="summaryOff" value="Не показвай съдържание по раздели в долния колонтитул"/>
 			</node>
-			<node name="showProgress" value="Номер на страницата">
-				<node name="summaryOn" value="Покажи номер на страницата в долния колонтитул"/>
-				<node name="summaryOff" value="Не показвай номер на страницата в долния колонтитул"/>
-			</node>
 			<node name="showBattery" value="Състояние на батерията">
 				<node name="summaryOn" value="Покажи състояние на батерията в долния колонтитул"/>
 				<node name="summaryOff" value="Не показвай състояние на батерията в долния колонтитул"/>

--- a/assets/resources/application/ca.xml
+++ b/assets/resources/application/ca.xml
@@ -715,10 +715,6 @@
 				<node name="summaryOn" value="Mostra les marques de contingut a la barra del peu de pàgina"/>
 				<node name="summaryOff" value="No mostris les marques de contingut a la barra del peu de pàgina"/>
 			</node>
-			<node name="showProgress" value="Mostra el número de la pàgina">
-				<node name="summaryOn" value="Mostra el número de la pàgina al peu de pàgina"/>
-				<node name="summaryOff" value="No mostrar número de página en el pie de página"/>
-			</node>
 			<node name="showBattery" value="Mostra la càrrega de la bateria">
 				<node name="summaryOn" value="Mostra la càrrega de la bateria al peu de pàgina"/>
 				<node name="summaryOff" value="No mostris la càrrega de la bateria al peu de pàgina"/>

--- a/assets/resources/application/cs.xml
+++ b/assets/resources/application/cs.xml
@@ -718,10 +718,6 @@
 				<node name="summaryOn" value="Zobrazit značky obsahu v patičce"/>
 				<node name="summaryOff" value="Nezobrazovat značky obsahu v patičce"/>
 			</node>
-			<node name="showProgress" value="Zobrazit číslo stránky">
-				<node name="summaryOn" value="Zobrazit číslo stránky v patičce"/>
-				<node name="summaryOff" value="Nezobrazovat číslo stránky v patičce"/>
-			</node>
 			<node name="showBattery" value="Zobrazit úroveň baterie">
 				<node name="summaryOn" value="Zobrazit úroveň baterie v patičce"/>
 				<node name="summaryOff" value="Nezobrazovat úroveň baterie v patičce"/>

--- a/assets/resources/application/da.xml
+++ b/assets/resources/application/da.xml
@@ -708,10 +708,6 @@
 				<node name="summaryOn" value="Vis indholdsfortegnelse-mærker i sidefoden"/>
 				<node name="summaryOff" value="Vis ikke indholdsfortegnelse-mærker i sidefoden"/>
 			</node>
-			<node name="showProgress" value="Vis sidetal">
-				<node name="summaryOn" value="Vis sidetal i sidefoden"/>
-				<node name="summaryOff" value="Vis ikke sidetal i sidefoden"/>
-			</node>
 			<node name="showBattery" value="Vis batteriniveau">
 				<node name="summaryOn" value="Vis batteriniveau i sidefoden"/>
 				<node name="summaryOff" value="Vis ikke batteriniveau i sidefoden"/>

--- a/assets/resources/application/de.xml
+++ b/assets/resources/application/de.xml
@@ -714,10 +714,6 @@
 				<node name="summaryOn" value="Kapitelmarken in der Fußzeile anzeigen"/>
 				<node name="summaryOff" value="Keine Kapitelmarken in der Fußzeile anzeigen"/>
 			</node>
-			<node name="showProgress" value="Seitennummer anzeigen">
-				<node name="summaryOn" value="Seitennummer in der Fußleiste anzeigen"/>
-				<node name="summaryOff" value="Keine Seitennummer in der Fußzeile anzeigen"/>
-			</node>
 			<node name="showBattery" value="Akkustatus">
 				<node name="summaryOn" value="Akkustatus in der Fußleiste anzeigen"/>
 				<node name="summaryOff" value="Keinen Akkustatus in der Fußleiste anzeigen"/>

--- a/assets/resources/application/el.xml
+++ b/assets/resources/application/el.xml
@@ -699,10 +699,6 @@
 				<node name="summaryOn" value="Εμφάνιση Κεφάλαιου στο υποσέλιδο."/>
 				<node name="summaryOff" value="Μη εμφάνιση Κεφάλαιου στο υποσέλιδο."/>
 			</node>
-			<node name="showProgress" value="Εμφάνιση αριθμού σελίδας">
-				<node name="summaryOn" value="Εμφάνιση αριθμού σελίδας στο υποσέλιδο."/>
-				<node name="summaryOff" value="Μη εμφάνιση αριθμού σελίδας στο υποσέλιδο."/>
-			</node>
 			<node name="showBattery" value="Εμφάνιση σύμβολου μπαταρίας">
 				<node name="summaryOn" value="Εμφάνιση σύμβολου μπαταρίας στο υποσέλιδο."/>
 				<node name="summaryOff" value="Μη εμφάνιση σύμβολου μπαταρίας στο υποσέλιδο."/>

--- a/assets/resources/application/en.xml
+++ b/assets/resources/application/en.xml
@@ -713,6 +713,10 @@
 				<node name="summaryOn" value="Show page number in footer"/>
 				<node name="summaryOff" value="Don't show page number in footer"/>
 			</node>
+			<node name="showProgressAsPercentage" value="Show pages as percentage">
+				<node name="summaryOn" value="Show progress as percentage in footer"/>
+				<node name="summaryOff" value="Show page number in footer"/>
+			</node>
 			<node name="showBattery" value="Show battery level">
 				<node name="summaryOn" value="Show battery level in footer"/>
 				<node name="summaryOff" value="Don't show battery level in footer"/>

--- a/assets/resources/application/en.xml
+++ b/assets/resources/application/en.xml
@@ -709,13 +709,11 @@
 				<node name="summaryOn" value="Show TOC marks in the footer bar"/>
 				<node name="summaryOff" value="Don't show TOC marks in the footer bar"/>
 			</node>
-			<node name="showProgress" value="Show page number">
-				<node name="summaryOn" value="Show page number in footer"/>
-				<node name="summaryOff" value="Don't show page number in footer"/>
-			</node>
-			<node name="showProgressAsPercentage" value="Show pages as percentage">
-				<node name="summaryOn" value="Show progress as percentage in footer"/>
-				<node name="summaryOff" value="Show page number in footer"/>
+			<node name="showProgressTypes" value="Show Progress">
+				<node name="hide" value="Do not show progress"/>
+				<node name="showProgressAsPages" value="As page numbers"/>
+				<node name="showProgressAsPercentage" value="As percentage"/>
+				<node name="showProgressAsBoth" value="As pages and percentage"/>
 			</node>
 			<node name="showBattery" value="Show battery level">
 				<node name="summaryOn" value="Show battery level in footer"/>

--- a/assets/resources/application/en_US.xml
+++ b/assets/resources/application/en_US.xml
@@ -713,6 +713,10 @@
 				<node name="summaryOn" value="Show page number in footer"/>
 				<node name="summaryOff" value="Don't show page number in footer"/>
 			</node>
+			<node name="showProgressAsPercentage" value="Show pages as percentage">
+				<node name="summaryOn" value="Show progress as percentage in footer"/>
+				<node name="summaryOff" value="Show page number in footer"/>
+			</node>
 			<node name="showBattery" value="Show battery level">
 				<node name="summaryOn" value="Show battery level in footer"/>
 				<node name="summaryOff" value="Don't show battery level in footer"/>

--- a/assets/resources/application/en_US.xml
+++ b/assets/resources/application/en_US.xml
@@ -709,13 +709,11 @@
 				<node name="summaryOn" value="Show TOC marks in the footer bar"/>
 				<node name="summaryOff" value="Don't show TOC marks in the footer bar"/>
 			</node>
-			<node name="showProgress" value="Show page number">
-				<node name="summaryOn" value="Show page number in footer"/>
-				<node name="summaryOff" value="Don't show page number in footer"/>
-			</node>
-			<node name="showProgressAsPercentage" value="Show pages as percentage">
-				<node name="summaryOn" value="Show progress as percentage in footer"/>
-				<node name="summaryOff" value="Show page number in footer"/>
+			<node name="showProgressTypes" value="Show Progress">
+				<node name="hide" value="Do not show progress"/>
+				<node name="showProgressAsPages" value="As page numbers"/>
+				<node name="showProgressAsPercentage" value="As percentage"/>
+				<node name="showProgressAsBoth" value="As pages and percentage"/>
 			</node>
 			<node name="showBattery" value="Show battery level">
 				<node name="summaryOn" value="Show battery level in footer"/>

--- a/assets/resources/application/es.xml
+++ b/assets/resources/application/es.xml
@@ -715,10 +715,6 @@
 				<node name="summaryOn" value="Mostrar las marcas de la TDC en la barra del pie de página"/>
 				<node name="summaryOff" value="No mostrar las marcas de la TDC en la barra del pie de página"/>
 			</node>
-			<node name="showProgress" value="Mostrar número de página">
-				<node name="summaryOn" value="Mostrar número de página en el pie de página"/>
-				<node name="summaryOff" value="No mostrar número de página en el pie de página"/>
-			</node>
 			<node name="showBattery" value="Mostrar carga de batería">
 				<node name="summaryOn" value="Mostrar la carga de la batería en el pie de página"/>
 				<node name="summaryOff" value="No mostrar la carga de la batería en el pie de página"/>

--- a/assets/resources/application/eu.xml
+++ b/assets/resources/application/eu.xml
@@ -709,10 +709,6 @@
 				<node name="summaryOn" value="Erakutsi aurkibidearen laster-markak oin-barran"/>
 				<node name="summaryOff" value="Ez erakutsi aurkibidearen laster-markak oin-barran"/>
 			</node>
-			<node name="showProgress" value="Erakutsi orri zenbakia">
-				<node name="summaryOn" value="Erakutsi orri zenbakia oinean"/>
-				<node name="summaryOff" value="Ez erakutsi orri zenbakia oinean"/>
-			</node>
 			<node name="showBattery" value="Erakutsi bateriaren karga">
 				<node name="summaryOn" value="Erakutsi bateriaren karga oinean"/>
 				<node name="summaryOff" value="Ez erakutsi bateriaren karga oinean"/>

--- a/assets/resources/application/fa.xml
+++ b/assets/resources/application/fa.xml
@@ -708,10 +708,6 @@
 				<node name="summaryOn" value="نمايش علائم در نوار زيربرگ فهرست مطالب"/>
 				<node name="summaryOff" value="عدم نمايش علائم در نوار زيربرگ فهرست مطالب"/>
 			</node>
-			<node name="showProgress" value="نمايش شماره صفحه">
-				<node name="summaryOn" value="نمايش شماره صفحه در زيربرگ"/>
-				<node name="summaryOff" value="عدم نمايش شماره صفحه در زيربرگ"/>
-			</node>
 			<node name="showBattery" value="نمايش سطح باتري">
 				<node name="summaryOn" value="نمايش سطح باتري در زيربرگ"/>
 				<node name="summaryOff" value="عدم نمايش سطح باتري در زيربرگ"/>

--- a/assets/resources/application/fr.xml
+++ b/assets/resources/application/fr.xml
@@ -702,10 +702,6 @@
 				<node name="summaryOn" value="Afficher les repères dans la barre du pied de page"/>
 				<node name="summaryOff" value="Ne pas afficher les repères dans la barre du pied de page"/>
 			</node>
-			<node name="showProgress" value="Afficher le numéro de page">
-				<node name="summaryOn" value="Affiche le numéro de la page dans le pied de page"/>
-				<node name="summaryOff" value="N'affiche page le numéro de page"/>
-			</node>
 			<node name="showBattery" value="Afficher le niveau de batterie">
 				<node name="summaryOn" value="Affiche le niveau de batterie dans le pied de page"/>
 				<node name="summaryOff" value="N'affiche pas le niveau de batterie"/>

--- a/assets/resources/application/gl.xml
+++ b/assets/resources/application/gl.xml
@@ -699,10 +699,6 @@
 				<node name="summaryOn" value="Mostrar as marcas do índice na barra do rodapé"/>
 				<node name="summaryOff" value="Non mostrar as marcas do índice na barra do rodapé"/>
 			</node>
-			<node name="showProgress" value="Mostrar número de páxina">
-				<node name="summaryOn" value="Mostrar número de páxina no rodapé"/>
-				<node name="summaryOff" value="Non mostrar número de páxina no rodapé"/>
-			</node>
 			<node name="showBattery" value="Mostrar a carga da batería">
 				<node name="summaryOn" value="Mostrar a carga da batería no rodapé"/>
 				<node name="summaryOff" value="Non mostrar a carga da batería no rodapé"/>

--- a/assets/resources/application/hu.xml
+++ b/assets/resources/application/hu.xml
@@ -699,10 +699,6 @@
 				<node name="summaryOn" value="Mutassa a tartalomjegyzék elemeit a láblécen"/>
 				<node name="summaryOff" value="Ne mutassa a tartalomjegyzék elemeit a láblécen"/>
 			</node>
-			<node name="showProgress" value="Oldalszám">
-				<node name="summaryOn" value="Mutassa az oldalszámot a láblécben"/>
-				<node name="summaryOff" value="Ne mutassa az oldalszámot a láblécben"/>
-			</node>
 			<node name="showBattery" value="Akku töltöttség">
 				<node name="summaryOn" value="Mutassa az akkumulátor töltöttségét a láblécben"/>
 				<node name="summaryOff" value="Ne mutassa az akkumulátor töltöttségét a láblécben"/>

--- a/assets/resources/application/hy.xml
+++ b/assets/resources/application/hy.xml
@@ -715,10 +715,6 @@
 				<node name="summaryOn" value="Դրոշմները ցուցադրել էջատակում, գլխի սկզբում"/>
 				<node name="summaryOff" value="Էջատակերը առանց դրոշմների"/>
 			</node>
-			<node name="showProgress" value="Էջերի համարակալում">
-				<node name="summaryOn" value="Էջի համարը ցուցադրել էջատակում"/>
-				<node name="summaryOff" value="Թաքցնել էջի համարը"/>
-			</node>
 			<node name="showBattery" value="Ցուցադրել մարտկոցի լիացքավորումը">
 				<node name="summaryOn" value="Մարտկոցի լիցքավորումը ցուցադրել էջատակում"/>
 				<node name="summaryOff" value="Թաքցնել մարտկոցի լիցքավորումը"/>

--- a/assets/resources/application/it.xml
+++ b/assets/resources/application/it.xml
@@ -700,10 +700,6 @@
 				<node name="summaryOn" value="Mostra segnalibri in basso"/>
 				<node name="summaryOff" value="Non mostrare segnalibri in basso"/>
 			</node>
-			<node name="showProgress" value="Mostra numero di pagina">
-				<node name="summaryOn" value="Mostra numero di pagina in barra piè di pagina"/>
-				<node name="summaryOff" value="Non mostrare numero di pagina in barra piè di pagina"/>
-			</node>
 			<node name="showBattery" value="Mostra livello batteria">
 				<node name="summaryOn" value="Mostra livello batteria in barra piè di pagina"/>
 				<node name="summaryOff" value="Non mostrare livello batteria in barra piè di pagina"/>

--- a/assets/resources/application/ja.xml
+++ b/assets/resources/application/ja.xml
@@ -709,10 +709,6 @@
 				<node name="summaryOn" value="フッタのバーに目次項目の印を表示する"/>
 				<node name="summaryOff" value="フッタのバーに目次項目の印を表示しない"/>
 			</node>
-			<node name="showProgress" value="ページ番号を表示">
-				<node name="summaryOn" value="フッタにページ番号を表示する"/>
-				<node name="summaryOff" value="フッタにページ番号を表示しない"/>
-			</node>
 			<node name="showBattery" value="電池残量を表示">
 				<node name="summaryOn" value="フッタに電池残量を表示する"/>
 				<node name="summaryOff" value="フッタに電池残量を表示しない"/>

--- a/assets/resources/application/ka.xml
+++ b/assets/resources/application/ka.xml
@@ -714,10 +714,6 @@
 				<node name="summaryOn" value="სარდაფზე ნიშნულის დახატვა თავის დასაწყისში"/>
 				<node name="summaryOff" value="სარდაფი ნიშნულების გარეშე"/>
 			</node>
-			<node name="showProgress" value="გვერდების რაოდენობის ჩვენება">
-				<node name="summaryOn" value="გვერდების რაოდენობის ჩვენება სარდაფში"/>
-				<node name="summaryOff" value="არ აჩვენო გვერდების რაოდენობა სარდაფში"/>
-			</node>
 			<node name="showBattery" value="ელემენტის მუხტის ჩვენება">
 				<node name="summaryOn" value="ელემენტის მუხტის ჩვენება სარდაფში"/>
 				<node name="summaryOff" value="არ აჩვენო ელემენტის მუხტი სარდაფში"/>

--- a/assets/resources/application/ko.xml
+++ b/assets/resources/application/ko.xml
@@ -709,10 +709,6 @@
 				<node name="summaryOn" value="꼬리말 바에 TOC 표시 보이기"/>
 				<node name="summaryOff" value="꼬리말 바에 TOC 표시 보이지 않음"/>
 			</node>
-			<node name="showProgress" value="페이지 번호 표시">
-				<node name="summaryOn" value="꼬리말 바에 페이지 번호를 표시합니다"/>
-				<node name="summaryOff" value="꼬리말 바에 페이지 번호를 표시하지 않습니다"/>
-			</node>
 			<node name="showBattery" value="배터리 잔량 표시">
 				<node name="summaryOn" value="꼬리말 바에 배터리 잔량을 표시합니다"/>
 				<node name="summaryOff" value="꼬리말 바에 배터리 잔량을 표시하지 않습니다"/>

--- a/assets/resources/application/nb.xml
+++ b/assets/resources/application/nb.xml
@@ -709,10 +709,6 @@
 				<node name="summaryOn" value="Vis merkene i innholdsfortegnelsen i bunntekstlinjen"/>
 				<node name="summaryOff" value="Ikke vis merkene i innholdsfortegnelsen i bunntekstlinjen"/>
 			</node>
-			<node name="showProgress" value="Vis sidetall">
-				<node name="summaryOn" value="Vis sidetall i bunnteksten"/>
-				<node name="summaryOff" value="Ikke vis sidetall i bunnteksten"/>
-			</node>
 			<node name="showBattery" value="Vis batterinivå">
 				<node name="summaryOn" value="Vis batterinivået i bunnteksten"/>
 				<node name="summaryOff" value="Ikke vis batterinivået i bunnteksten"/>

--- a/assets/resources/application/nl.xml
+++ b/assets/resources/application/nl.xml
@@ -709,10 +709,6 @@
 				<node name="summaryOn" value="Toon inhoudsmarkeringen in onderbalk"/>
 				<node name="summaryOff" value="Verberg inhoudsmarkeringen in onderbalk"/>
 			</node>
-			<node name="showProgress" value="Toon paginanummer">
-				<node name="summaryOn" value="Toon paginanummer in onderbalk"/>
-				<node name="summaryOff" value="Verberg paginanummer in onderbalk"/>
-			</node>
 			<node name="showBattery" value="Toon batterijniveau">
 				<node name="summaryOn" value="Toon batterijniveau in onderbalk"/>
 				<node name="summaryOff" value="Verberg batterijniveau in onderbalk"/>

--- a/assets/resources/application/pl.xml
+++ b/assets/resources/application/pl.xml
@@ -699,10 +699,6 @@
 				<node name="summaryOn" value="Pokazuj znaczniki w stopce"/>
 				<node name="summaryOff" value="Nie pokazuj znaczników w stopce"/>
 			</node>
-			<node name="showProgress" value="Pokazywanie numeru strony">
-				<node name="summaryOn" value="Pokzuj numer strony w stopce"/>
-				<node name="summaryOff" value="Nie pokazuj numeru strony w stopce"/>
-			</node>
 			<node name="showBattery" value="Pokazywanie poziomu baterii">
 				<node name="summaryOn" value="Pokazuj poziom baterii w stopce"/>
 				<node name="summaryOff" value="Nie pokazuj poziomu baterii w stopce"/>

--- a/assets/resources/application/pt.xml
+++ b/assets/resources/application/pt.xml
@@ -713,10 +713,6 @@
 				<node name="summaryOn" value="Mostrar marcas de TOC na barra de rodapé"/>
 				<node name="summaryOff" value="Não mostrar marcas de TOC na barra de rodapé"/>
 			</node>
-			<node name="showProgress" value="Mostrar número de página">
-				<node name="summaryOn" value="Mostrar número de página no rodapé"/>
-				<node name="summaryOff" value="Não mostrar o número da página no rodapé"/>
-			</node>
 			<node name="showBattery" value="Mostrar nível de bateria">
 				<node name="summaryOn" value="Mostrar nível de bateria no rodapé"/>
 				<node name="summaryOff" value="Não mostrar o nível da bateria no rodapé"/>

--- a/assets/resources/application/ro.xml
+++ b/assets/resources/application/ro.xml
@@ -702,10 +702,6 @@
 				<node name="summaryOn" value="Arata favoritele curpinsului în bara de subsol"/>
 				<node name="summaryOff" value="Nu arata semne de cuprins în bara de subsol"/>
 			</node>
-			<node name="showProgress" value="Arata numarul paginii">
-				<node name="summaryOn" value="Afiseaza numarul paginii în subsol"/>
-				<node name="summaryOff" value="Nu arata numarul paginii în subsol"/>
-			</node>
 			<node name="showBattery" value="Afiseaza nivelul bateriei">
 				<node name="summaryOn" value="Afiseaza nivelul bateriei în subsol"/>
 				<node name="summaryOff" value="Nu afisa nivelul bateriei în subsol"/>

--- a/assets/resources/application/ru.xml
+++ b/assets/resources/application/ru.xml
@@ -714,10 +714,6 @@
 				<node name="summaryOn" value="Рисовать пометку на подвале в начале главы"/>
 				<node name="summaryOff" value="Подвал без пометок"/>
 			</node>
-			<node name="showProgress" value="Показывать число страниц">
-				<node name="summaryOn" value="Показывать число страниц в подвале"/>
-				<node name="summaryOff" value="Не показывать число страниц в подвале"/>
-			</node>
 			<node name="showBattery" value="Показать заряд батареи">
 				<node name="summaryOn" value="Показывать заряд батареи в подвале"/>
 				<node name="summaryOff" value="Не показывать заряд батареи в подвале"/>

--- a/assets/resources/application/sr.xml
+++ b/assets/resources/application/sr.xml
@@ -709,10 +709,6 @@
 				<node name="summaryOn" value="Приказује ознаке садржаја у подножју."/>
 				<node name="summaryOff" value="Не приказује ознаке садржаја у подножју."/>
 			</node>
-			<node name="showProgress" value="Број странице">
-				<node name="summaryOn" value="Приказује број странице у подножју."/>
-				<node name="summaryOff" value="Не приказује број странице у подножју."/>
-			</node>
 			<node name="showBattery" value="Ниво батерије">
 				<node name="summaryOn" value="Приказује ниво батерије у подножју."/>
 				<node name="summaryOff" value="Не приказује ниво батерије у подножју."/>

--- a/assets/resources/application/th.xml
+++ b/assets/resources/application/th.xml
@@ -699,10 +699,6 @@
 				<node name="summaryOn" value="แสดงสารบัญท้ายหน้า"/>
 				<node name="summaryOff" value="ไม่แสดงสัญลักษณ์สารบัญท้ายหน้า"/>
 			</node>
-			<node name="showProgress" value="แสดงเลขหน้า">
-				<node name="summaryOn" value="แสดงเลขหน้าที่ท้ายหน้า"/>
-				<node name="summaryOff" value="ไม่แสดงเลขหน้าที่ท้ายหน้า"/>
-			</node>
 			<node name="showBattery" value="แสดงระดับแบตเตอรี่">
 				<node name="summaryOn" value="แสดงระดับแบตเตอรี่ที่ท้ายหน้า"/>
 				<node name="summaryOff" value="ไม่แสดงระดับแบตเตอรี่ที่ท้ายหน้า"/>

--- a/assets/resources/application/tr.xml
+++ b/assets/resources/application/tr.xml
@@ -709,10 +709,6 @@
 				<node name="summaryOn" value="İçerik işaretlerini altbilgi kısmında göster"/>
 				<node name="summaryOff" value="İçerik işaretlerini altbilgi kısmında gösterme"/>
 			</node>
-			<node name="showProgress" value="Sayfa numarası göster">
-				<node name="summaryOn" value="Altbilgide sayfa numarası göster"/>
-				<node name="summaryOff" value="Altbilgide sayfa numarası gösterme"/>
-			</node>
 			<node name="showBattery" value="Pil durumunu göster">
 				<node name="summaryOn" value="Altbilgide pil durumunu göster"/>
 				<node name="summaryOff" value="Altbilgide pil durumunu gösterme"/>

--- a/assets/resources/application/uk.xml
+++ b/assets/resources/application/uk.xml
@@ -699,10 +699,6 @@
 				<node name="summaryOn" value="Показувати відмітки TOC в підвалі"/>
 				<node name="summaryOff" value="Не показувати відмітки TOC в підвалі"/>
 			</node>
-			<node name="showProgress" value="Показувати номер сторінки">
-				<node name="summaryOn" value="Показувати номер сторінки в підвалі"/>
-				<node name="summaryOff" value="Не показувати номер сторінки в підвалі"/>
-			</node>
 			<node name="showBattery" value="Показувати рівень заяду">
 				<node name="summaryOn" value="Показувати рівень заяду в підвалі"/>
 				<node name="summaryOff" value="Не показувати рівень заяду в підвалі"/>

--- a/assets/resources/application/vi.xml
+++ b/assets/resources/application/vi.xml
@@ -700,10 +700,6 @@
 				<node name="summaryOn" value="Hiện đánh dấu mục lục ở thanh cuối trang"/>
 				<node name="summaryOff" value="Không Hiện đánh dấu mục lục ở thanh cuối trang"/>
 			</node>
-			<node name="showProgress" value="Hiện số trang">
-				<node name="summaryOn" value="Hiện số trang ở dòng cuối"/>
-				<node name="summaryOff" value="Đừng hiện số trang ở dòng cuối"/>
-			</node>
 			<node name="showBattery" value="Hiện lượng pin">
 				<node name="summaryOn" value="Hiện lượng pin ở dòng cuối"/>
 				<node name="summaryOff" value="Đừng hiện lượng pin ở dòng cuối"/>

--- a/assets/resources/application/zh.xml
+++ b/assets/resources/application/zh.xml
@@ -699,10 +699,6 @@
 				<node name="summaryOn" value="在页脚栏显示内容目录标志"/>
 				<node name="summaryOff" value="不在页脚栏显示内容目录标志"/>
 			</node>
-			<node name="showProgress" value="显示页码">
-				<node name="summaryOn" value="在页脚显示页码"/>
-				<node name="summaryOff" value="不在页脚显示页码"/>
-			</node>
 			<node name="showBattery" value="显示电量百分比">
 				<node name="summaryOn" value="在页脚显示电量百分比"/>
 				<node name="summaryOff" value="不在页脚显示电量百分比"/>

--- a/assets/resources/application/zh_TW.xml
+++ b/assets/resources/application/zh_TW.xml
@@ -699,10 +699,6 @@
 				<node name="summaryOn" value="在頁尾顯示目錄標示"/>
 				<node name="summaryOff" value="不要在頁尾顯示目錄標示"/>
 			</node>
-			<node name="showProgress" value="顯示頁碼">
-				<node name="summaryOn" value="在頁尾顯示頁碼"/>
-				<node name="summaryOff" value="不要在頁尾顯示頁碼"/>
-			</node>
 			<node name="showBattery" value="顯示電量">
 				<node name="summaryOn" value="在頁尾顯示電量"/>
 				<node name="summaryOff" value="不要在頁尾顯示電量"/>

--- a/src/org/geometerplus/android/fbreader/preferences/PreferenceActivity.java
+++ b/src/org/geometerplus/android/fbreader/preferences/PreferenceActivity.java
@@ -558,6 +558,7 @@ public class PreferenceActivity extends ZLPreferenceActivity {
 		footerPreferences.add(statusLineScreen.addOption(footerOptions.ShowTOCMarks, "tocMarks"));
 
 		footerPreferences.add(statusLineScreen.addOption(footerOptions.ShowProgress, "showProgress"));
+		footerPreferences.add(statusLineScreen.addOption(footerOptions.ShowProgressAsPercentage, "showProgressAsPercentage"));
 		footerPreferences.add(statusLineScreen.addOption(footerOptions.ShowClock, "showClock"));
 		footerPreferences.add(statusLineScreen.addOption(footerOptions.ShowBattery, "showBattery"));
 		footerPreferences.add(statusLineScreen.addPreference(new FontPreference(

--- a/src/org/geometerplus/android/fbreader/preferences/PreferenceActivity.java
+++ b/src/org/geometerplus/android/fbreader/preferences/PreferenceActivity.java
@@ -557,8 +557,12 @@ public class PreferenceActivity extends ZLPreferenceActivity {
 		newStyleFooterPreferences.add(statusLineScreen.addOption(profile.FooterNGForegroundUnreadOption, "footerForegroundUnreadColor"));
 		footerPreferences.add(statusLineScreen.addOption(footerOptions.ShowTOCMarks, "tocMarks"));
 
-		footerPreferences.add(statusLineScreen.addOption(footerOptions.ShowProgress, "showProgress"));
-		footerPreferences.add(statusLineScreen.addOption(footerOptions.ShowProgressAsPercentage, "showProgressAsPercentage"));
+
+		statusLineScreen.addPreference(new ZLChoicePreference(
+				this, statusLineScreen.Resource.getResource("showProgressTypes"),
+				footerOptions.ShowProgressType, footerOptions.getProgressValueResourceKeys()
+		));
+
 		footerPreferences.add(statusLineScreen.addOption(footerOptions.ShowClock, "showClock"));
 		footerPreferences.add(statusLineScreen.addOption(footerOptions.ShowBattery, "showBattery"));
 		footerPreferences.add(statusLineScreen.addPreference(new FontPreference(

--- a/src/org/geometerplus/android/fbreader/preferences/PreferenceActivity.java
+++ b/src/org/geometerplus/android/fbreader/preferences/PreferenceActivity.java
@@ -557,11 +557,17 @@ public class PreferenceActivity extends ZLPreferenceActivity {
 		newStyleFooterPreferences.add(statusLineScreen.addOption(profile.FooterNGForegroundUnreadOption, "footerForegroundUnreadColor"));
 		footerPreferences.add(statusLineScreen.addOption(footerOptions.ShowTOCMarks, "tocMarks"));
 
-
 		statusLineScreen.addPreference(new ZLChoicePreference(
 				this, statusLineScreen.Resource.getResource("showProgressTypes"),
 				footerOptions.ShowProgressType, footerOptions.getProgressValueResourceKeys()
-		));
+		) {
+			@Override
+			public boolean isEnabled() {
+				int scrollbarType = viewOptions.ScrollbarType.getValue();
+				return scrollbarType == FBView.SCROLLBAR_SHOW_AS_FOOTER ||
+						scrollbarType == FBView.SCROLLBAR_SHOW_AS_FOOTER_OLD_STYLE;
+			}
+		});
 
 		footerPreferences.add(statusLineScreen.addOption(footerOptions.ShowClock, "showClock"));
 		footerPreferences.add(statusLineScreen.addOption(footerOptions.ShowBattery, "showBattery"));

--- a/src/org/geometerplus/fbreader/fbreader/FBView.java
+++ b/src/org/geometerplus/fbreader/fbreader/FBView.java
@@ -532,9 +532,13 @@ public final class FBView extends ZLTextView {
 			final StringBuilder info = new StringBuilder();
 			final FooterOptions footerOptions = myViewOptions.getFooterOptions();
 			if (footerOptions.ShowProgress.getValue()) {
-				info.append(pagePosition.Current);
-				info.append("/");
-				info.append(pagePosition.Total);
+				if (footerOptions.ShowProgressAsPercentage.getValue()) {
+					info.append(pagePosition.getPercentageString());
+				} else {
+					info.append(pagePosition.Current);
+					info.append("/");
+					info.append(pagePosition.Total);
+				}
 			}
 			if (footerOptions.ShowClock.getValue()) {
 				if (info.length() > 0) {
@@ -546,6 +550,7 @@ public final class FBView extends ZLTextView {
 				if (info.length() > 0) {
 					info.append(separator);
 				}
+				info.append("⚡ ");
 				info.append(myReader.getBatteryLevel());
 				info.append("%");
 			}

--- a/src/org/geometerplus/fbreader/fbreader/FBView.java
+++ b/src/org/geometerplus/fbreader/fbreader/FBView.java
@@ -531,30 +531,35 @@ public final class FBView extends ZLTextView {
 		protected String buildInfoString(PagePosition pagePosition, String separator) {
 			final StringBuilder info = new StringBuilder();
 			final FooterOptions footerOptions = myViewOptions.getFooterOptions();
-			if (footerOptions.ShowProgress.getValue()) {
-				if (footerOptions.ShowProgressAsPercentage.getValue()) {
-					info.append(pagePosition.getPercentageString());
-				} else {
-					info.append(pagePosition.Current);
-					info.append("/");
-					info.append(pagePosition.Total);
-				}
+
+			if (footerOptions.showProgressAsPages()) {
+				maybeAddSeparator(separator, info);
+				info.append(pagePosition.Current);
+				info.append("/");
+				info.append(pagePosition.Total);
 			}
+			if (footerOptions.showProgressAsPercentage()) {
+				maybeAddSeparator(separator, info);
+				info.append(pagePosition.getPercentageString());
+			}
+
 			if (footerOptions.ShowClock.getValue()) {
-				if (info.length() > 0) {
-					info.append(separator);
-				}
+				maybeAddSeparator(separator, info);
 				info.append(ZLibrary.Instance().getCurrentTimeString());
 			}
 			if (footerOptions.ShowBattery.getValue()) {
-				if (info.length() > 0) {
-					info.append(separator);
-				}
+				maybeAddSeparator(separator, info);
 				info.append("⚡ ");
 				info.append(myReader.getBatteryLevel());
 				info.append("%");
 			}
 			return info.toString();
+		}
+
+		private void maybeAddSeparator(String separator, StringBuilder info) {
+			if (info.length() > 0) {
+                info.append(separator);
+            }
 		}
 
 		private List<FontEntry> myFontEntry;

--- a/src/org/geometerplus/fbreader/fbreader/options/FooterOptions.java
+++ b/src/org/geometerplus/fbreader/fbreader/options/FooterOptions.java
@@ -25,16 +25,46 @@ public class FooterOptions {
 	public final ZLBooleanOption ShowTOCMarks;
 	public final ZLBooleanOption ShowClock;
 	public final ZLBooleanOption ShowBattery;
-	public final ZLBooleanOption ShowProgress;
-	public final ZLBooleanOption ShowProgressAsPercentage;
+
+	public final ZLIntegerRangeOption ShowProgressType;
+
 	public final ZLStringOption Font;
 
 	public FooterOptions() {
 		ShowTOCMarks = new ZLBooleanOption("Options", "FooterShowTOCMarks", true);
 		ShowClock = new ZLBooleanOption("Options", "ShowClockInFooter", true);
 		ShowBattery = new ZLBooleanOption("Options", "ShowBatteryInFooter", true);
-		ShowProgress = new ZLBooleanOption("Options", "ShowProgressInFooter", true);
-		ShowProgressAsPercentage = new ZLBooleanOption("Options", "ShowProgressInFooterAsPercentage", false);
 		Font = new ZLStringOption("Options", "FooterFont", "Droid Sans");
+
+		ShowProgressType = new ZLIntegerRangeOption("Options", "ShowProgressType", 0, 4, ProgressTypes.showProgressAsPages.ordinal());
 	}
+
+	public boolean showProgressAsPercentage() {
+		return ShowProgressType.getValue() == ProgressTypes.showProgressAsPercentage.ordinal() ||
+				ShowProgressType.getValue() == ProgressTypes.showProgressAsBoth.ordinal();
+	}
+
+	public boolean showProgressAsPages() {
+		return ShowProgressType.getValue() == ProgressTypes.showProgressAsPages.ordinal() ||
+				ShowProgressType.getValue() == ProgressTypes.showProgressAsBoth.ordinal();
+	}
+
+
+	public String[] getProgressValueResourceKeys() {
+		ProgressTypes[] progressTypes = ProgressTypes.values();
+		String[] resourceKeys = new String[progressTypes.length];
+
+		for (int i = 0; i < progressTypes.length; i++) {
+			resourceKeys[i] = progressTypes[i].name();
+		}
+
+		return resourceKeys;
+	}
+}
+
+enum ProgressTypes {
+	hide,
+	showProgressAsPages,
+	showProgressAsPercentage,
+	showProgressAsBoth
 }

--- a/src/org/geometerplus/fbreader/fbreader/options/FooterOptions.java
+++ b/src/org/geometerplus/fbreader/fbreader/options/FooterOptions.java
@@ -26,6 +26,7 @@ public class FooterOptions {
 	public final ZLBooleanOption ShowClock;
 	public final ZLBooleanOption ShowBattery;
 	public final ZLBooleanOption ShowProgress;
+	public final ZLBooleanOption ShowProgressAsPercentage;
 	public final ZLStringOption Font;
 
 	public FooterOptions() {
@@ -33,6 +34,7 @@ public class FooterOptions {
 		ShowClock = new ZLBooleanOption("Options", "ShowClockInFooter", true);
 		ShowBattery = new ZLBooleanOption("Options", "ShowBatteryInFooter", true);
 		ShowProgress = new ZLBooleanOption("Options", "ShowProgressInFooter", true);
+		ShowProgressAsPercentage = new ZLBooleanOption("Options", "ShowProgressInFooterAsPercentage", false);
 		Font = new ZLStringOption("Options", "FooterFont", "Droid Sans");
 	}
 }

--- a/src/org/geometerplus/zlibrary/text/view/ZLTextView.java
+++ b/src/org/geometerplus/zlibrary/text/view/ZLTextView.java
@@ -706,6 +706,11 @@ public abstract class ZLTextView extends ZLTextViewBase {
 			Current = current;
 			Total = total;
 		}
+
+		public String getPercentageString() {
+			float percentage = ((float) Current / Total) * 100;
+			return String.format("%.0f%%", percentage);
+		}
 	}
 
 	public final synchronized PagePosition pagePosition() {


### PR DESCRIPTION
If progress is show: This toggles between showing the percentage completed and the number of pages completed.

Also added a battery unicode symbol in front of the battery display, to clearly show the point of that percentage.